### PR TITLE
Add space animation

### DIFF
--- a/app/src/main/java/com/scallop/jetpackcomposeviews/customviews/Annimations.kt
+++ b/app/src/main/java/com/scallop/jetpackcomposeviews/customviews/Annimations.kt
@@ -1,0 +1,79 @@
+package com.scallop.jetpackcomposeviews.customviews
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+
+data class Star(
+    var x: Float,
+    var y: Float,
+    var alpha: Float,
+) {
+    private val initialAlpha = alpha
+
+    fun update(value: Float) {
+        val x = (value - initialAlpha).toDouble()
+        val newAlpha = 0.5f + (0.5f * Math.sin(x).toFloat())
+        alpha = newAlpha
+    }
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+@Composable
+fun Space(
+    modifier: Modifier = Modifier
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val infinitelyAnimatedFloat = infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 2f * Math.PI.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(10000),
+            repeatMode = RepeatMode.Restart
+        )
+    )
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .fillMaxHeight(),
+    ) {
+        val width = maxWidth.toPx()
+        val height = maxHeight.toPx()
+        val stars = remember {
+            buildList {
+                repeat(1000) {
+                    val x = (Math.random() * width).toFloat()
+                    val y = (Math.random() * height).toFloat()
+                    val alpha = (Math.random() * 2.0 * Math.PI).toFloat()
+                    add(Star(x, y, alpha))
+                }
+            }
+        }
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(),
+        ) {
+            for (star in stars) {
+                star.update(infinitelyAnimatedFloat.value)
+                drawCircle(
+                    color = Color.White,
+                    center = Offset(star.x, star.y),
+                    radius = 2f,
+                    alpha = star.alpha,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/scallop/jetpackcomposeviews/customviews/Annimations.kt
+++ b/app/src/main/java/com/scallop/jetpackcomposeviews/customviews/Annimations.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 
 data class Star(
     var x: Float,
@@ -48,8 +49,9 @@ fun Space(
             .fillMaxWidth()
             .fillMaxHeight(),
     ) {
-        val width = maxWidth.toPx()
-        val height = maxHeight.toPx()
+        val density = LocalDensity.current
+        val width = with(density) { maxWidth.toPx() }
+        val height = with(density) { maxHeight.toPx() }
         val stars = remember {
             buildList {
                 repeat(1000) {


### PR DESCRIPTION
## Summary
- Adds a space/star field animation composable
- Fixes `toPx()` compilation error by wrapping Dp-to-px conversions with `LocalDensity`

## Test plan
- [ ] Navigate to the animation screen and verify stars render and animate correctly
- [ ] Verify no visual regressions in other screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)